### PR TITLE
Fix CSS background-image syntax

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,7 +29,7 @@ body {
   color: var(--text-color);
   display: block;
   cursor: url('assets/other effects/chrome star.png') 16 16, auto;
-  background-image: url('assets/other effects/sparkle bg.png'), var(--bg-color);
+  background-image: url('assets/other effects/sparkle bg.png');
   background-repeat: repeat;
   background-size: auto;
   background-position: top left;


### PR DESCRIPTION
## Summary
- fix invalid `background-image` property in `style.css`

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844bb550ca483258aa1e2e720740c5d