### PR TITLE
Fix marquee repetition

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,18 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Space+Grotesk&display=swap" rel="stylesheet">
 </head>
 <body class="theme-icy">
-  <div class="marquee-container">
-    <div class="marquee-track">
-      <span class="marquee-text" data-text="BOOF AVE™">BOOF AVE™</span>
+    <div class="marquee-container">
+      <div class="marquee-track">
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+        <span class="marquee-text">BOOF AVE™</span>
+      </div>
     </div>
-  </div>
   <header class="site-header">
     <img src="assets/logos/icy blue y2k logo 1.png" alt="BOOF AVE Logo" class="logo"/>
     <p>Welcome to BOOF AVE</p>

--- a/style.css
+++ b/style.css
@@ -316,11 +316,6 @@ h1, h2, h3, h4, h5, h6 {
   color: #fff;
   font-family: 'Orbitron', sans-serif;
   padding: 0 2.5rem;
-  position: relative;
-}
-.marquee-text::after {
-  content: attr(data-text);
-  padding-left: 5rem;
 }
 @keyframes marquee {
   0%   { transform: translateX(0); }


### PR DESCRIPTION
## Summary
- duplicate marquee text spans so the scroll is continuous
- remove old marquee-text `::after` pseudo-element

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844c791b45c83258bed985bf62a8b5d