### PR TITLE
Replace portfolio with service descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,18 +58,18 @@
         <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/0M1LZjAHdDktpEYYoUerxV?utm_source=generator&theme=0" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
       </div>
       <div class="section-box portfolio-box">
-        <h2>Cool $H!T</h2>
+        <h2>Our Services</h2>
         <div class="portfolio-grid">
           <div class="card"><img src="assets/portfolio/project1.png" alt="Project 1" style="width:100%;height:100%;object-fit:cover;"></div>
+          <div class="card service-card"><h3>Design</h3><p>Custom graphics and visuals for your brand.</p></div>
           <div class="card"><img src="assets/portfolio/project2.png" alt="Project 2" style="width:100%;height:100%;object-fit:cover;"></div>
+          <div class="card service-card"><h3>Branding</h3><p>Logos and identity systems that pop.</p></div>
           <div class="card"><img src="assets/portfolio/project3.png" alt="Project 3" style="width:100%;height:100%;object-fit:cover;"></div>
+          <div class="card service-card"><h3>Digital Art</h3><p>Illustrations and NFTs built for the web.</p></div>
           <div class="card"><img src="assets/portfolio/project4.png" alt="Project 4" style="width:100%;height:100%;object-fit:cover;"></div>
+          <div class="card service-card"><h3>Video Production</h3><p>From music videos to promos, we film it all.</p></div>
           <div class="card"><img src="assets/portfolio/project5.png" alt="Project 5" style="width:100%;height:100%;object-fit:cover;"></div>
-          <div class="card"><img src="assets/portfolio/project6.png" alt="Project 6" style="width:100%;height:100%;object-fit:cover;"></div>
-          <div class="card"><img src="assets/portfolio/project7.png" alt="Project 7" style="width:100%;height:100%;object-fit:cover;"></div>
-          <div class="card"><img src="assets/portfolio/project8.png" alt="Project 8" style="width:100%;height:100%;object-fit:cover;"></div>
-          <div class="card"><img src="assets/portfolio/project9.png" alt="Project 9" style="width:100%;height:100%;object-fit:cover;"></div>
-          <div class="card"><img src="assets/portfolio/project10.png" alt="Project 10" style="width:100%;height:100%;object-fit:cover;"></div>
+          <div class="card service-card"><h3>Event Curation</h3><p>Planning and hosting experiences on the Ave.</p></div>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -268,6 +268,26 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 1.1rem;
 }
 
+/* Service description cards */
+.portfolio-grid .service-card {
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  text-align: left;
+  padding: 0 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.portfolio-grid .service-card h3 {
+  margin: 0 0 4px 0;
+  font-size: 1rem;
+}
+.portfolio-grid .service-card p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
 /* Space between last section and footer (desktop) */
 .left-panel > .section-box:last-child,
 .right-panel > .section-box:last-child {


### PR DESCRIPTION
## Summary
- rename **Cool $H!T** to **Our Services**
- keep five project images aligned left and show service descriptions on the right
- add CSS for service description cards

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844d21e64f88325a514584561d0642e