### PR TITLE
Add loading gif in services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
           <div class="card"><img src="assets/portfolio/project5.png" alt="Project 5" style="width:100%;height:100%;object-fit:cover;"></div>
           <div class="card service-card"><h3>Event Curation</h3><p>Planning and hosting experiences on the Ave.</p></div>
         </div>
+        <img class="services-loading" src="assets/gifs/loading.gif" alt="Loading animation" />
       </div>
     </section>
   </main>

--- a/style.css
+++ b/style.css
@@ -374,3 +374,10 @@ h1, h2, h3, h4, h5, h6 {
   from { opacity: 1; transform: translate(-50%, -50%) scale(1); }
   to { opacity: 0; transform: translate(-50%, -50%) scale(0); }
 }
+
+/* Loading gif below services */
+.services-loading {
+  display: block;
+  width: 60px;
+  margin: 16px auto 0 auto;
+}


### PR DESCRIPTION
## Summary
- show a loading animation at the end of the services grid
- style the gif so it centers beneath the cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844e20d0a548325bcd5ad17cb7b73f3