### PR TITLE
Update cursor trail sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,7 +34,8 @@ body {
   background: var(--bg-color);
   color: var(--text-color);
   display: block;
-  cursor: url('assets/other effects/sparkle.png') 16 16, auto;
+  /* Adjusted hotspot to match new sparkle dimensions */
+  cursor: url('assets/other effects/sparkle.png') 10 16, auto;
   background-image: url('assets/other effects/sparkle bg.png');
   background-repeat: repeat;
   background-size: auto;
@@ -364,8 +365,9 @@ h1, h2, h3, h4, h5, h6 {
 .cursor-trail {
   pointer-events: none;
   position: fixed;
-  width: 16px;
-  height: 16px;
+  /* Updated dimensions to better match sparkle image aspect ratio */
+  width: 21px;
+  height: 32px;
   transform: translate(-50%, -50%);
   animation: trail-fade 0.8s linear forwards;
 }


### PR DESCRIPTION
## Summary
- adjust sparkle cursor hotspot coordinates
- enlarge sparkle trail dimensions to match the cursor image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844e5284f888325b6fcf5913558adac