### PR TITLE
Adjust cursor and extend sparkle effect

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,8 +34,7 @@ body {
   background: var(--bg-color);
   color: var(--text-color);
   display: block;
-  /* Cursor image separate from trailing sparkle */
-  cursor: url('assets/other effects/sparkle-cursor.png') 10 16, auto;
+  cursor: auto;
   background-image: url('assets/other effects/sparkle bg.png');
   background-repeat: repeat;
   background-size: auto;
@@ -382,7 +381,7 @@ h1, h2, h3, h4, h5, h6 {
   width: 21px;
   height: 32px;
   transform: translate(-50%, -50%);
-  animation: trail-fade 2s linear forwards;
+  animation: trail-fade 4s linear forwards;
 }
 
 @keyframes trail-fade {

--- a/theme.js
+++ b/theme.js
@@ -14,5 +14,5 @@ document.addEventListener("mousemove", (e) => {
   trail.style.left = `${e.clientX}px`;
   trail.style.top = `${e.clientY}px`;
   document.body.appendChild(trail);
-  setTimeout(() => trail.remove(), 2000);
+  setTimeout(() => trail.remove(), 4000);
 });


### PR DESCRIPTION
## Summary
- remove custom cursor so default arrow shows
- extend the trailing sparkle animation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847482fa2fc832585a7b7fc12aed7e5