### PR TITLE
Update sparkle color and IG link styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -167,6 +167,10 @@ h1, h2, h3, h4, h5, h6 {
   position: static;
   border-radius: 0;
 }
+/* About section links inherit text color so they match the active theme */
+.about-box a {
+  color: inherit;
+}
 .friends-box {
   background: #133a5c;
   color: #fff;

--- a/theme.js
+++ b/theme.js
@@ -4,6 +4,11 @@ toggleBtn && toggleBtn.addEventListener("click", () => {
   const body = document.body;
   body.classList.toggle("theme-dark");
   body.classList.toggle("theme-icy");
+  if (body.classList.contains("theme-dark")) {
+    updateSparkleColor("#FFFFFF");
+  } else {
+    updateSparkleColor("#C0C0C0");
+  }
 });
 
 var colour="#C0C0C0";
@@ -46,10 +51,11 @@ window.onload=function() { if (document.getElementById) {
    rlef.style.left="0px";
    rdow.style.top="0px";
    rdow.style.left="2px";
-   document.body.appendChild(star[i]=rats);
- }
- set_width();
- sparkle();
+  document.body.appendChild(star[i]=rats);
+}
+set_width();
+ updateSparkleColor(document.body.classList.contains("theme-dark") ? "#FFFFFF" : "#C0C0C0");
+sparkle();
 }};
 function sparkle() {
  var c;
@@ -163,4 +169,17 @@ function createDiv(height, width) {
  div.style.overflow="hidden";
  div.style.backgroundColor=colour;
  return (div);
+}
+
+function updateSparkleColor(newColor) {
+  colour = newColor;
+  for (var i = 0; i < sparkles; i++) {
+    if (tiny[i]) {
+      tiny[i].style.backgroundColor = newColor;
+    }
+    if (star[i] && star[i].children.length >= 2) {
+      star[i].children[0].style.backgroundColor = newColor;
+      star[i].children[1].style.backgroundColor = newColor;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- adjust IG link font color to inherit from About Us text
- update sparkle color when toggling themes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475cc682088325af7a9ec3f86efa9c