### PR TITLE
Center services section with multiple images

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
   <main class="main-columns">
     <section class="left-panel">
       <div id="about" class="section-box about-box">
-        <img class="profile-pic" src="assets/logos/white-logo.png" alt="BOOF AVE profile logo" />
         <h2>About Us</h2>
+        <img class="profile-pic" src="assets/logos/white-logo.png" alt="BOOF AVE profile logo" />
         <p>
           We are a creative collective dedicated to bringing your brand and design ideas to life. Check out our featured services and favorite artists, BRB!
         </p>
@@ -83,20 +83,64 @@
         <h2>Artists on the Ave</h2>
         <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/0M1LZjAHdDktpEYYoUerxV?utm_source=generator&theme=0" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
       </div>
-      <div id="services" class="section-box portfolio-box">
+      <div id="services" class="section-box portfolio-box services-box">
         <h2>Our Services</h2>
-        <div class="portfolio-grid">
-          <div class="card"><img src="assets/the-mentalchemist-logo.png" alt="Project 1"></div>
-          <div class="card service-card"><h3>Branding</h3><p>Custom logos and other visuals for your brand. $25-100</p></div>
-          <div class="card"><img src="assets/kupenda-product-rebrand.png" alt="Project 2"></div>
-          <div class="card service-card"><h3>Design</h3><p>Cover art, merchandise/product packaging, website design, and more. $100-500</p></div>
-          <div class="card"><img src="assets/boofed-boy-shoot.png" alt="Project 3"></div>
-          <div class="card service-card"><h3>Photo Production</h3><p>Curated shots and edits for clothing or merch. $75/hr</p></div>
-          <div class="card"><img src="assets/jarel-cupid-shoot.png" alt="Project 4"></div>
-          <div class="card service-card"><h3>Video Production</h3><p>Filming and editing everything from music videos to promos. $100/hr</p></div>
-          <div class="card"><img src="assets/funhouse-flyer-2.png" alt="Project 5"></div>
-          <div class="card service-card"><h3>Event Curation</h3><p>Planning and hosting experiences on the Ave. $500</p></div>
+
+        <div class="service">
+          <div class="service-images">
+            <img src="assets/the-mentalchemist-logo.png" alt="Branding example 1">
+            <img src="assets/the-mentalchemist-logo.png" alt="Branding example 2">
+            <img src="assets/the-mentalchemist-logo.png" alt="Branding example 3">
+            <img src="assets/the-mentalchemist-logo.png" alt="Branding example 4">
+          </div>
+          <h3>Branding</h3>
+          <p>Custom logos and other visuals for your brand. $25-100</p>
         </div>
+
+        <div class="service">
+          <div class="service-images">
+            <img src="assets/kupenda-product-rebrand.png" alt="Design example 1">
+            <img src="assets/kupenda-product-rebrand.png" alt="Design example 2">
+            <img src="assets/kupenda-product-rebrand.png" alt="Design example 3">
+            <img src="assets/kupenda-product-rebrand.png" alt="Design example 4">
+          </div>
+          <h3>Design</h3>
+          <p>Cover art, merchandise/product packaging, website design, and more. $100-500</p>
+        </div>
+
+        <div class="service">
+          <div class="service-images">
+            <img src="assets/boofed-boy-shoot.png" alt="Photo production example 1">
+            <img src="assets/boofed-boy-shoot.png" alt="Photo production example 2">
+            <img src="assets/boofed-boy-shoot.png" alt="Photo production example 3">
+            <img src="assets/boofed-boy-shoot.png" alt="Photo production example 4">
+          </div>
+          <h3>Photo Production</h3>
+          <p>Curated shots and edits for clothing or merch. $75/hr</p>
+        </div>
+
+        <div class="service">
+          <div class="service-images">
+            <img src="assets/jarel-cupid-shoot.png" alt="Video production example 1">
+            <img src="assets/jarel-cupid-shoot.png" alt="Video production example 2">
+            <img src="assets/jarel-cupid-shoot.png" alt="Video production example 3">
+            <img src="assets/jarel-cupid-shoot.png" alt="Video production example 4">
+          </div>
+          <h3>Video Production</h3>
+          <p>Filming and editing everything from music videos to promos. $100/hr</p>
+        </div>
+
+        <div class="service">
+          <div class="service-images">
+            <img src="assets/funhouse-flyer-2.png" alt="Event curation example 1">
+            <img src="assets/funhouse-flyer-2.png" alt="Event curation example 2">
+            <img src="assets/funhouse-flyer-2.png" alt="Event curation example 3">
+            <img src="assets/funhouse-flyer-2.png" alt="Event curation example 4">
+          </div>
+          <h3>Event Curation</h3>
+          <p>Planning and hosting experiences on the Ave. $500</p>
+        </div>
+
         <img class="services-loading" src="assets/gifs/loading.gif" alt="Loading animation" />
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -104,7 +104,9 @@ h1, h2, h3, h4, h5, h6 {
 .profile-pic {
   width: 120px;
   height: 120px;
-  border-radius: 50%;
+  border-radius: 12px;
+  border: 2px solid var(--accent-color);
+  background: #fff;
   display: block;
   margin: 0 0 16px 0;
 }
@@ -183,7 +185,19 @@ h1, h2, h3, h4, h5, h6 {
   box-sizing: border-box;
   position: static;
 }
-.about-box {
+/* Center headers for non-services sections */
+.about-box h2,
+.spotify-box h2,
+.friends-box h2,
+.form-box h2 {
+  text-align: center;
+}
+/* Section box styles */
+.about-box,
+.friends-box,
+.form-box,
+.spotify-box,
+.portfolio-box {
   background: #133a5c;
   color: #fff;
   width: 100%;
@@ -193,34 +207,6 @@ h1, h2, h3, h4, h5, h6 {
 /* About section links inherit text color so they match the active theme */
 .about-box a {
   color: inherit;
-}
-.friends-box {
-  background: #133a5c;
-  color: #fff;
-  width: 100%;
-  position: static;
-  border-radius: 0;
-}
-.form-box {
-  background: #133a5c;
-  color: #fff;
-  width: 100%;
-  position: static;
-  border-radius: 0;
-}
-.spotify-box {
-  background: #133a5c;
-  color: #fff;
-  width: 100%;
-  position: static;
-  border-radius: 0;
-}
-.portfolio-box {
-  background: #133a5c;
-  color: #fff;
-  width: 100%;
-  position: static;
-  border-radius: 0;
 }
 
 /* In dark mode, service text switches to black */
@@ -427,4 +413,35 @@ h1, h2, h3, h4, h5, h6 {
   width: 120px;
   height: 120px;
   margin: 16px auto 0 auto;
+}
+
+/* Centered layout for services section */
+.services-box {
+  text-align: center;
+}
+.services-box .service {
+  margin-top: 24px;
+}
+.services-box .service-images {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.services-box .service-images img {
+  width: 100%;
+  aspect-ratio: 1/1;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 2px solid var(--accent-color);
+  background: #fff;
+}
+.services-box .service h3 {
+  margin: 8px 0 4px 0;
+  font-size: 1rem;
+}
+.services-box .service p {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: normal;
 }


### PR DESCRIPTION
## Summary
- center the entire services area
- show four images per service
- center service names and descriptions under the images
- align headers in other sections and compress duplicated styles
- moved About Us heading above profile pic and matched border styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b24f318308325bdacbf0be5e6d863