### PR TITLE
Adjust icy theme text colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -88,7 +88,7 @@ h1, h2, h3, h4, h5, h6 {
 .site-header, .site-footer {
   width: 100%;
   background: var(--primary-color);
-  color: #fff;
+  color: var(--text-color);
   text-align: center;
   padding: 32px 0 16px 0;
   font-family: 'Orbitron', sans-serif;
@@ -122,7 +122,7 @@ h1, h2, h3, h4, h5, h6 {
 .site-header p {
   margin: 0 0 8px 0;
   font-size: 1.1rem;
-  color: #e0f1fb;
+  color: var(--text-color);
 }
 
 .quick-links {
@@ -146,7 +146,7 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 12px;
   padding: 8px 20px;
   background: var(--accent-color);
-  color: #fff;
+  color: var(--text-color);
   border: none;
   border-radius: 8px;
   font-family: 'Orbitron', sans-serif;
@@ -237,12 +237,13 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0 auto;
   padding: 10px 28px;
   background: var(--accent-color);
-  color: #fff;
+  color: var(--text-color);
   border: none;
   border-radius: 8px;
   font-size: 1.1rem;
   text-decoration: none;
   font-family: 'Orbitron', sans-serif;
+  text-align: center;
   transition: background 0.2s;
 }
 .portal-btn:hover {
@@ -360,7 +361,7 @@ h1, h2, h3, h4, h5, h6 {
   display: inline-block;
   white-space: nowrap;
   font-size: 2.5rem;
-  color: #fff;
+  color: var(--text-color);
   font-family: 'Orbitron', sans-serif;
   padding: 0 2.5rem;
 }


### PR DESCRIPTION
## Summary
- center portal button text
- use theme text color for header, footer, marquee, and buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b70d41ef083258b7a64b784436f8d